### PR TITLE
Support run task(s) when module name similar task name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `0.0.2`
+
+- Enhancements
+  * Support run task(s) when module name similar task name ([#13](https://github.com/namnv609/tasks-migration/issues/13))
+  * Add option `--no-suffix` to remove `Task` suffix from task name
+
 ## `0.0.1`
 
 - Release gem

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This command will create 2 files:
 Create a new task by command:
 
 ```
-rails generate tasks_migration:task <TaskName>
+rails generate tasks_migration:task <TaskName> [--no-suffix]
 ```
 
 Business Logic will be handled in method `self.excute` on file  `app/migration_tasks/<task_name>.rb`. Example:

--- a/lib/generators/tasks_migration/task_generator.rb
+++ b/lib/generators/tasks_migration/task_generator.rb
@@ -4,10 +4,15 @@ module TasksMigration
   module Generators
     class TaskGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("../templates", __FILE__)
+      class_option "no-suffix", type: :boolean, default: false,
+        desc: "Remove Task suffix for task class name"
 
       desc "Add new migration task"
       def add_task
-        template "task.rb", "app/migration_tasks/#{name.underscore}_task.rb", name: name
+        task_file_suffix = "_task" unless options["no-suffix"]
+        task_file_name = "#{name.underscore}#{task_file_suffix}.rb"
+
+        template "task.rb", "app/migration_tasks/#{task_file_name}"
       end
     end
   end

--- a/lib/generators/tasks_migration/templates/task.rb
+++ b/lib/generators/tasks_migration/templates/task.rb
@@ -1,4 +1,4 @@
-class <%= name %>Task
+class <%= name.classify %><%= "Task" unless options["no-suffix"] %>
   def self.execute
     # Logic here
   end

--- a/lib/tasks_migration/migrate.rb
+++ b/lib/tasks_migration/migrate.rb
@@ -9,8 +9,11 @@ module TasksMigration
         executed_tasks = TasksMigrationSchema.pluck :version
 
         (all_tasks - executed_tasks).each do |task|
-          puts "Running task #{task}..."
-          task.constantize.execute
+          task_name = task.classify
+
+          puts "Running task #{task_name}..."
+          task_name.constantize.execute
+
           TasksMigrationSchema.create version: task
         end
       end


### PR DESCRIPTION
- Enhancements
  * Support run task(s) when module name similar task name ([#13](https://github.com/namnv609/tasks-migration/issues/13))
  * Add option `--no-suffix` to remove `Task` suffix from task name